### PR TITLE
fix for pandas default NA values in `pd.read_table()`

### DIFF
--- a/gffpandas/gffpandas.py
+++ b/gffpandas/gffpandas.py
@@ -57,7 +57,6 @@ class Gff3DataFrame(object):
                 self.header = ''.join([line for line in file_content.readlines() if line.startswith("#")])
         except:
             pass
-        print(self.header)
         return self.header
 
     def _to_xsv(self, output_file=None, sep=None) -> None:

--- a/gffpandas/gffpandas.py
+++ b/gffpandas/gffpandas.py
@@ -42,6 +42,7 @@ class Gff3DataFrame(object):
                 "phase",
                 "attributes",
             ],
+            keep_default_na=False,
         )
         return self.df
 


### PR DESCRIPTION
This PR adds the line `keep_default_na=False` to the `pd.read_table()` function.

This is a minor but necessary change as pandas normally replaces string values such as "NA" or "NONE" to `NaN`. However a string such as "NA" may be present when, for example, processing the NA-segment of Influenza.

## Example:

Loading in a gff3 file with the following contents of Influenza:

```
##gff-version 3
##species Influenza A
PB2	.	CDS	37	2316	.	+	.	ID=gene-PB2;Name=PB2;gene=PB2;gene_biotype=protein_coding;gene_name=PB2
PB1	.	CDS	34	2307	.	+	.	ID=gene-PB1;Name=PB1;gene=PB1;gene_biotype=protein_coding;gene_name=PB1
PA	.	CDS	35	2185	.	+	.	ID=gene-PA;Name=PA;gene=PA;gene_biotype=protein_coding;gene_name=PA
HA	.	CDS	40	1740	.	+	.	ID=gene-HA;Name=HA;gene=HA;gene_biotype=protein_coding;gene_name=HA
NP	.	CDS	34	1530	.	+	.	ID=gene-NP;Name=NP;gene=NP;gene_biotype=protein_coding;gene_name=NP
NA	.	CDS	30	1439	.	+	.	ID=gene-NA;Name=NA;gene=NA;gene_biotype=protein_coding;gene_name=NA
MP	.	CDS	36	794	.	+	.	ID=gene-MP1;Name=MP1;gene=MP1;gene_biotype=protein_coding;gene_name=MP1
MP	.	CDS	727	1017	.	+	.	ID=gene-MP2;Name=MP2;gene=MP2;gene_biotype=protein_coding;gene_name=MP2
NS	.	CDS	37	729	.	+	.	ID=gene-NS1;Name=NS1;gene=NS1;gene_biotype=protein_coding;gene_name=NS1
NS	.	CDS	554	874	.	+	.	ID=gene-NS2;Name=NS2;gene=NS2;gene_biotype=protein_coding;gene_name=NS2
```

will result in the pandas dataframe containing the following information:

```
>>> gff.df
  seq_id source type  start   end score strand phase  attributes
0    PB2      .  CDS     37  2316     .      +     .  ID=gene-PB2;Name=PB2;gene=PB2;g...
1    PB1      .  CDS     34  2307     .      +     .  ID=gene-PB1;Name=PB1;gene=PB1;g...
2     PA      .  CDS     35  2185     .      +     .  ID=gene-PA;Name=PA;gene=PA;gene_...
3     HA      .  CDS     40  1740     .      +     .  ID=gene-HA;Name=HA;gene=HA;gene_...
4     NP      .  CDS     34  1530     .      +     .  ID=gene-NP;Name=NP;gene=NP;gene_...
5    NaN      .  CDS     30  1439     .      +     .  ID=gene-NA;Name=NA;gene=NA;gene_...
6     MP      .  CDS     36   794     .      +     .  ID=gene-MP1;Name=MP1;gene=MP1;ge...
7     MP      .  CDS    727  1017     .      +     .  ID=gene-MP2;Name=MP2;gene=MP2;ge...
8     NS      .  CDS     37   729     .      +     .  ID=gene-NS1;Name=NS1;gene=NS1;ge...
9     NS      .  CDS    554   874     .      +     .  ID=gene-NS2;Name=NS2;gene=NS2;ge...
```

Please note how the seq_id of the NA segment became `NaN` in the resulting dataframe, thus resulting in invalid information.